### PR TITLE
getRelatedProducts function added to db/products.js

### DIFF
--- a/Tests/endpoint.test.js
+++ b/Tests/endpoint.test.js
@@ -7,29 +7,25 @@ describe('Product api has the expected endpoints', () => {
   it('should have a GET /products endpoint', () => {
     return pactum.spec()
       .get('http://localhost:3000/products')
-      .expectStatus(200)
-      .expectBody('Here be products');
+      .expectStatus(200);
   });
 
   it('should have a GET /products/:product_id endpoint', () => {
     return pactum.spec()
       .get('http://localhost:3000/products/123456')
-      .expectStatus(200)
-      .expectBody('Here be one product you requested');
+      .expectStatus(200);
   });
 
   it('should have a GET /products/:product_id/styles endpoint', () => {
     return pactum.spec()
       .get('http://localhost:3000/products/123456/styles')
-      .expectStatus(200)
-      .expectBody('Here be the styles you requested');
+      .expectStatus(200);
   });
 
   it('should have a GET /products/product_id/related endpoint', () => {
     return pactum.spec()
       .get('http://localhost:3000/products/123456/related')
-      .expectStatus(200)
-      .expectBody('Here be the related products you requested');
+      .expectStatus(200);
   });
 
 });

--- a/Tests/productDB.test.js
+++ b/Tests/productDB.test.js
@@ -1,4 +1,4 @@
-const {getProducts, getProduct} = require('../db/Product.js');
+const {getProducts, getProduct, getRelatedProducts} = require('../db/Product.js');
 
 describe('Getting Products', () => {
 
@@ -37,7 +37,6 @@ describe('Getting a Product', () => {
   it('getProducts should return a product with an id that matches the passed in id', () => {
     return getProduct(12321)
     .then((product) => {
-      debugger;
       expect(product.id).toBe(12321);
     })
     .catch((err) => {
@@ -53,3 +52,21 @@ describe('Getting a Product', () => {
   })
 
 });
+
+describe('Getting related products', () => {
+
+  it('getRelatedProducts should be a function', () => {
+    expect(typeof getRelatedProducts).toBe('function');
+  })
+
+  it('getRelatedProducts should resolve to an array', () => {
+    return getRelatedProducts(123433)
+    .then((relatedProducts) => {
+      debugger;
+      expect(Array.isArray(relatedProducts)).toBe(true);
+    })
+  })
+
+  
+
+})

--- a/db/Product.js
+++ b/db/Product.js
@@ -1,5 +1,5 @@
 const {DataTypes, Op} = require('sequelize');
-const {sequelize, Product, Feature} = require('./db.js');
+const {sequelize, Product, Feature, RelatedProduct} = require('./db.js');
 
 
 
@@ -39,7 +39,27 @@ const getProduct = (id) => {
 };
 
 
+const getRelatedProducts = (product_id) => {
+  // Get the related_product_id for the passed in product_id
+  return RelatedProduct.findAll({
+    attributes: [
+      'related_product_id'
+    ],
+    where: {
+      current_product_id: product_id
+    }
+  })
+  // Then we need to change the returned models into an array of just the values
+  .then((models) => {
+    return models.map((model) => {
+      return model.related_product_id;
+    })
+  })
+}
+
+
 module.exports = {
   getProducts,
-  getProduct
+  getProduct,
+  getRelatedProducts
 };

--- a/db/db.js
+++ b/db/db.js
@@ -2,8 +2,8 @@ const {Sequelize, DataTypes, Op} = require('sequelize');
 const {USER_NAME, PASSWORD} = require('../config/config.js');
 
 const sequelize = new Sequelize('product-info', USER_NAME, PASSWORD, {
-  timestamps: false,
-  dialect: 'postgres'
+  dialect: 'postgres',
+  logging: false
 });
 
 const Product = sequelize.define('Product', {
@@ -70,8 +70,18 @@ const Photo = sequelize.define('Photo', {
 });
 
 // I'm not sure how to do a relational set up and will need to look into this
-const Related_Product = sequelize.define('Relate_Product', {
-
+const RelatedProduct = sequelize.define('Related_Product', {
+  id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    primaryKey: true
+  },
+  current_product_id: {
+    type: DataTypes.INTEGER
+  },
+  related_product_id: {
+    type: DataTypes.INTEGER
+  }
 }, {
   timestamps: false
 });
@@ -96,7 +106,7 @@ const Sku = sequelize.define('Sku', {
 });
 
 const Style = sequelize.define('Style', {
-  id: {
+  style_id: {
     type: DataTypes.INTEGER,
     allowNull: false,
     primaryKey: true
@@ -113,8 +123,8 @@ const Style = sequelize.define('Style', {
   original_price: {
     type: DataTypes.INTEGER
   },
-  default_price: {
-    type: DataTypes.INTEGER
+  default_style: {
+    type: DataTypes.BOOLEAN
   }
 }, {
   timestamps: false
@@ -126,7 +136,7 @@ module.exports = {
   Product,
   Feature,
   Photo,
-  Related_Product,
+  RelatedProduct,
   Sku,
   Style
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,197 @@
+/*
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/private/var/folders/xq/64htb5g970s74s_q8pdp670w0000gn/T/jest_dx",
+
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  collectCoverage: true,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: "coverage",
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: "v8",
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  moduleNameMapper: {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "./__mocks__/fileMock.js",
+    "\\.(css|less)$": "identity-obj-proxy"
+  },
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: "jsdom",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [
+  //   "**/__tests__/**/*.[jt]s?(x)",
+  //   "**/?(*.)+(spec|test).[tj]s?(x)"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jest-circus/runner",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/",
+  //   "\\.pnp\\.[^\\/]+$"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon server/app.js",
-    "test": "test"
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR is mainly adding a getRelatedProducts function to db/products.js

I also changed my tests some though and added a jest.config.js file so that my tests will also print out a coverage report.

[Trello Ticket](https://trello.com/c/YbFC0kOY)

Tests:
![image](https://user-images.githubusercontent.com/54276174/142739486-c436e6c5-731c-4ca5-914f-807279d8337c.png)
